### PR TITLE
[BUG] router does not handle query strings correctly

### DIFF
--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -102,6 +102,8 @@ class Router
      */
     public function dispatch(string $method, string $uri): mixed
     {
+        $uri = parse_url($uri, PHP_URL_PATH);
+
         if (!empty($this->basePath) && strpos($uri, $this->basePath) === 0) {
             $basePathLength = strlen($this->basePath);
             if (strlen($uri) === $basePathLength || $uri[$basePathLength] === '/') {

--- a/tests/Unit/RouterTest.php
+++ b/tests/Unit/RouterTest.php
@@ -37,4 +37,14 @@ class RouterTest extends TestCase
         $this->expectException(\Exception::class);
         $this->router->dispatch('GET', '/non-existent');
     }
+
+    public function testRouteWithQueryString(): void
+    {
+        $this->router->add('GET', '/about', function () {
+            return 'About Us';
+        });
+
+        $response = $this->router->dispatch('GET', '/about?test=12345&qs=qs');
+        $this->assertEquals('About Us', $response);
+    }
 }


### PR DESCRIPTION
### **User description**
## 📑 Description
Close #110 [BUG] router does not handle query strings correctly

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Fixed the router to correctly handle query strings in URIs.
- Added a test case to verify the correct behavior of routing with query strings.
- Updated documentation to reflect changes in router functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Router.php</strong><dd><code>Fix URI parsing to handle query strings in Router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Router/Router.php
<li>Added parsing of the URI to handle query strings correctly.<br> <li> Updated the <code>dispatch</code> method to process the path from the URI.<br>


</details>


  </td>
  <td><a href="https://github.com/GuilhermeStracini/POC-php-mvc/pull/111/files#diff-67264ebd47657b45f34968b896460d1de5605e437de43133be9b2d9fb181f27f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RouterTest.php</strong><dd><code>Add test for routing with query strings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/RouterTest.php
<li>Added a test case for routing with query strings.<br> <li> Ensured the router correctly dispatches requests with query <br>parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/GuilhermeStracini/POC-php-mvc/pull/111/files#diff-73c85ed2cc097135ec9928cc15d0884cbfb0910569b4dd2866067775685c05a0">+10/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved URL handling to ensure that only the path segment is used for routing. This update prevents issues with query strings affecting page navigation, resulting in more accurate route matching and a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->